### PR TITLE
load_class seems fine, module tree needed correction

### DIFF
--- a/t/mojolicious/lib/MojoliciousLoaderTest/Controller/Foo.pm
+++ b/t/mojolicious/lib/MojoliciousLoaderTest/Controller/Foo.pm
@@ -1,0 +1,7 @@
+package MojoliciousLoaderTest::Controller::Foo;
+
+use Mojo::Base 'Mojolicious::Controller';
+
+sub index {}
+
+1;

--- a/t/mojolicious/lib/MojoliciousLoaderTest/Controller/Foo/Bar.pm
+++ b/t/mojolicious/lib/MojoliciousLoaderTest/Controller/Foo/Bar.pm
@@ -1,4 +1,4 @@
-package MojoliciousLoaderTest::Foo::Bar;
+package MojoliciousLoaderTest::Controller::Foo::Bar;
 
 use Mojo::Base 'Mojolicious::Controller';
 


### PR DESCRIPTION
### Summary
`Controller` was not in the namespace (`MojoliciousLoaderTest::Controller::Foo::Bar`) and the `::Foo` module didn't exist. `Controller` isn't required, but the actual module `MojoliciousLoaderTest::Foo` (or ``MojoliciousLoaderTest::Controller::Foo`) is. The error is possibly misleading.

### Motivation
Doesn't appear to be a bug in `Mojo`.

### References
kraih/mojo#1125